### PR TITLE
Replace '+' and '*' chars in packages name by '\+' and '\*'

### DIFF
--- a/kiosk_interface/views/custom_package_item.py
+++ b/kiosk_interface/views/custom_package_item.py
@@ -289,7 +289,7 @@ def search_icon_by_name(name):
 
     # Research the prefix in name value of icon_list
     for icon in icon_list:
-        if re.match(prefix, icon["name"], re.I):
+        if re.match(prefix.replace('+', '\+').replace('*', '\*'), icon["name"], re.I):
             return icon["name"] + "." + icon["ext"]
     return False
 


### PR DESCRIPTION
Basic example:
'Notepad++' as pattern generates an error because of '++' which is interpreted as 2 regex '+' operators.